### PR TITLE
docs: consume DelEx evidence and gate model in bounties

### DIFF
--- a/START-HERE.md
+++ b/START-HERE.md
@@ -1,0 +1,20 @@
+# START HERE — DelEx Bounties
+
+This repository is the incentive and payout layer for DelEx.
+
+It should consume upstream engagement, gate, evidence, and reusable-asset semantics rather than define delivery truth locally.
+
+## Read in this order
+
+1. `docs/README.md`
+2. `docs/evidence-scoring-alignment.md`
+3. `docs/payout-gates-from-delivery-gates.md`
+4. `docs/incentive-surface-boundaries.md`
+5. `docs/worked-example-customer-success-support.md`
+
+## Upstream dependencies
+
+- `delivery-excellence` for canon and shared object model
+- `delivery-excellence-automation` for schemas and validated examples
+- `delivery-excellence-boards` for portfolio/gate/dependency visibility
+- `delivery-excellence-innersource` for reusable-asset promotion semantics

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,21 @@
+# DelEx Bounties Consumption Layer
+
+This repo should consume upstream DelEx evidence, gate, and reusable-asset semantics.
+
+It should not define delivery truth on its own.
+
+## Upstream sources of truth
+
+- `SocioProphet/delivery-excellence` for prose canon, shared object model, gates, and governance method
+- `SocioProphet/delivery-excellence-automation` for schemas, examples, and validation
+
+## Primary docs here
+
+1. [Evidence Scoring Alignment](evidence-scoring-alignment.md)
+2. [Payout Gates from Delivery Gates](payout-gates-from-delivery-gates.md)
+3. [Incentive Surface Boundaries](incentive-surface-boundaries.md)
+4. [Worked Example: Customer Success Support Accelerator](worked-example-customer-success-support.md)
+
+## Design rule
+
+A bounty or payout decision should consume upstream engagement, delivery gate, evidence, and reusable-asset state rather than inventing local delivery semantics.

--- a/docs/evidence-scoring-alignment.md
+++ b/docs/evidence-scoring-alignment.md
@@ -1,0 +1,46 @@
+# Evidence Scoring Alignment
+
+## Purpose
+
+Deterministic bounty scoring should reward validated delivery evidence, not unverified activity.
+
+## Inputs bounty logic should consume
+
+### Engagement
+The engagement identifies the commercial and operational context. A bounty should be attributable to a real delivery instance, not a free-floating task.
+
+### Delivery Gate
+A bounty should know which gate the work supports or completes.
+
+Examples:
+- readiness baseline evidence
+- shadow-mode readiness evidence
+- controlled-action pilot evidence
+
+### Evidence links
+Acceptable evidence may include:
+- PRs
+- validation reports
+- dashboards
+- runbooks
+- ADRs
+- approved gate reviews
+
+### Reusable Asset status
+A bounty may increase in weight when work produces or improves a reusable asset with evidence of reuse value.
+
+### Exception and rollback context
+If work triggered high-severity exceptions, stop-work, or rollback, scoring should reflect that reality rather than ignoring it.
+
+## Anti-patterns
+
+Do not score:
+- raw commit count
+- message volume
+- self-asserted completion
+- activity without evidence
+- work that bypassed gates or policy constraints
+
+## Alignment principle
+
+Bounties should amplify proof-backed delivery, not create incentives to rush around DelEx controls.

--- a/docs/incentive-surface-boundaries.md
+++ b/docs/incentive-surface-boundaries.md
@@ -1,0 +1,37 @@
+# Incentive Surface Boundaries
+
+## Purpose
+
+This repo should make clear what incentives may and may not influence.
+
+## Incentives may reinforce
+
+- completion of validated evidence packages
+- closure of high-value client dependencies
+- production of reusable assets with proven reuse value
+- reduction of blocked work when proof and approvals exist
+- successful gate progression supported by evidence
+
+## Incentives must not override
+
+- action class restrictions
+- policy approvals
+- security or risk controls
+- stop-work decisions
+- rollback decisions
+- customer-facing approval rules
+
+## Hard boundaries
+
+No bounty rule should encourage:
+- bypassing approvals
+- reducing evidence requirements
+- hiding exceptions or incidents
+- inflating activity without delivery proof
+- widening autonomy without gate approval
+
+## Governance implication
+
+Bounty logic is downstream of DelEx governance. It is not a parallel governance system.
+
+If a bounty design conflicts with DelEx controls, the bounty design should change.

--- a/docs/payout-gates-from-delivery-gates.md
+++ b/docs/payout-gates-from-delivery-gates.md
@@ -1,0 +1,54 @@
+# Payout Gates from Delivery Gates
+
+## Purpose
+
+Payout should not be a separate truth system. It should be derived from DelEx delivery gates and the evidence required to pass them.
+
+## Core rule
+
+No payout decision should be final unless the relevant delivery gate evidence is present and the required approvals exist.
+
+## Mapping
+
+### Gate-aligned payout examples
+
+#### Readiness baseline support
+Possible reward condition:
+- dependency evidence completed
+- baseline package validated
+- accountable owner accepts the evidence
+
+#### Shadow readiness support
+Possible reward condition:
+- review surfaces and telemetry are present
+- validation reports exist
+- failure taxonomy or tuning evidence is linked
+
+#### Controlled-action pilot support
+Possible reward condition:
+- rollback evidence exists
+- policy signoff exists
+- approved action subset is recorded
+- exception queue is staffed
+
+## Required payout evidence
+
+A payout decision should be able to point to:
+- linked engagement
+- linked gate
+- linked evidence artifacts
+- approval record
+- decision owner
+- escrow reference, if used
+
+## Stop conditions
+
+Payout should be blocked when:
+- gate evidence is incomplete
+- approvals are missing
+- severe exception or rollback invalidates completion
+- work was superseded or rejected in gate review
+
+## Why this matters
+
+If payout ignores delivery gates, incentives can undermine governance. If payout derives from delivery gates, incentives reinforce the same control system.

--- a/docs/worked-example-customer-success-support.md
+++ b/docs/worked-example-customer-success-support.md
@@ -1,0 +1,37 @@
+# Worked Example: Customer Success Support Accelerator
+
+## Purpose
+
+Show how bounty semantics should be derived from the upstream customer-success/support example rather than invented independently.
+
+## Upstream objects in play
+
+- engagement: `eng.customer-success.support-001`
+- control loop: `cl.customer-success.support-intake`
+- delivery gates:
+  - `gate.readiness-baseline`
+  - `gate.controlled-action-pilot`
+- reusable asset:
+  - `asset.cs-support-autonomy-envelope-template`
+
+## Example rewardable outputs
+
+### Dependency closure
+If knowledge-base metadata cleanup is completed, validated, and accepted as part of readiness-baseline evidence, that work may be rewardable.
+
+### Reusable asset creation
+If the autonomy-envelope template is promoted as a reusable asset with evidence of reuse value, that work may carry higher weight than one-off local cleanup.
+
+### Gate-supporting validation work
+If rollback proof, policy signoff packaging, or intervention dashboards materially enable the controlled-action pilot gate, those artifacts may support bounty reward.
+
+## Example non-rewardable outputs
+
+- unreviewed draft replies
+- activity without evidence links
+- attempts to widen autonomy without approval
+- work invalidated by rollback or failed gate review
+
+## Takeaway
+
+The reward signal should follow proof-backed progress in the delivery control system. It should not operate as a separate market detached from DelEx governance.


### PR DESCRIPTION
## Summary

Map `delivery-excellence-bounties` onto the stabilized DelEx engagement / gate / evidence / reusable-asset model so incentive semantics stay downstream of proof.

## Adds

- docs index for bounties as a DelEx consumption layer
- evidence scoring alignment to engagement, gate, evidence, reusable-asset, and exception context
- payout gating derived from delivery gates
- incentive boundary rules that explicitly subordinate bounty logic to DelEx governance
- worked example using the customer-success/support accelerator objects
- root `START-HERE.md` front-door guide

## Why

The bounty layer should not act as a parallel governance system. It should reinforce the same control system defined upstream in `delivery-excellence` and validated in `delivery-excellence-automation`.

## Follow-up

- later, if needed, encode payout-decision objects in the automation repo after the repo-level semantics settle
- keep token/escrow mechanics downstream of engagement, evidence, and gate completion semantics
